### PR TITLE
APEX-514 Calculate min utxo

### DIFF
--- a/sendtx/tx_sender.go
+++ b/sendtx/tx_sender.go
@@ -94,7 +94,7 @@ func (txSnd *TxSender) CreateBridgingTx(
 	bridgingFee uint64,
 	exchangeRate ExchangeRate,
 ) ([]byte, string, *BridgingRequestMetadata, error) {
-	metadata, err := txSnd.CreateMetadata(senderAddr, srcChainID, dstChainID, receivers, bridgingFee, exchangeRate)
+	metadata, err := txSnd.CreateMetadata(ctx, senderAddr, srcChainID, dstChainID, receivers, bridgingFee, exchangeRate)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -128,7 +128,7 @@ func (txSnd *TxSender) CalculateBridgingTxFee(
 	bridgingFee uint64,
 	exchangeRate ExchangeRate,
 ) (uint64, *BridgingRequestMetadata, error) {
-	metadata, err := txSnd.CreateMetadata(senderAddr, srcChainID, dstChainID, receivers, bridgingFee, exchangeRate)
+	metadata, err := txSnd.CreateMetadata(ctx, senderAddr, srcChainID, dstChainID, receivers, bridgingFee, exchangeRate)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -201,6 +201,7 @@ func (txSnd *TxSender) SubmitTx(
 }
 
 func (txSnd *TxSender) CreateMetadata(
+	ctx context.Context,
 	senderAddr string,
 	srcChainID string,
 	dstChainID string,
@@ -264,7 +265,7 @@ func (txSnd *TxSender) CreateMetadata(
 			}
 
 			if !paramsSetSrc {
-				params, err := srcConfig.TxProvider.GetProtocolParameters(context.Background())
+				params, err := srcConfig.TxProvider.GetProtocolParameters(ctx)
 				if err != nil {
 					return nil, err
 				}
@@ -301,7 +302,7 @@ func (txSnd *TxSender) CreateMetadata(
 			}
 
 			if !paramsSetDst {
-				params, err := dstConfig.TxProvider.GetProtocolParameters(context.Background())
+				params, err := dstConfig.TxProvider.GetProtocolParameters(ctx)
 				if err != nil {
 					return nil, err
 				}

--- a/sendtx/tx_sender_test.go
+++ b/sendtx/tx_sender_test.go
@@ -1,6 +1,7 @@
 package sendtx
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Ethernal-Tech/cardano-infrastructure/common"
@@ -30,7 +31,7 @@ func TestCreateMetaData(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		txSnd := NewTxSender(configs)
 
-		metadata, err := txSnd.CreateMetadata(senderAddr, "prime", "vector", []BridgingTxReceiver{
+		metadata, err := txSnd.CreateMetadata(context.Background(), senderAddr, "prime", "vector", []BridgingTxReceiver{
 			{
 				BridgingType: BridgingTypeNormal,
 				Addr:         "addr1_aa",
@@ -89,7 +90,7 @@ func TestCreateMetaData(t *testing.T) {
 			},
 		})
 
-		metadata, err := txSnd.CreateMetadata(senderAddr, "prime", "vector", []BridgingTxReceiver{
+		metadata, err := txSnd.CreateMetadata(context.Background(), senderAddr, "prime", "vector", []BridgingTxReceiver{
 			{
 				BridgingType: BridgingTypeNativeTokenOnSource,
 				Addr:         "addr1_ab",
@@ -118,7 +119,7 @@ func TestCreateMetaData(t *testing.T) {
 		txSnd := NewTxSender(configs)
 
 		_, err := txSnd.CreateMetadata(
-			senderAddr, "prime", "vector1", []BridgingTxReceiver{}, bridgingFeeAmount, exchangeRate)
+			context.Background(), senderAddr, "prime", "vector1", []BridgingTxReceiver{}, bridgingFeeAmount, exchangeRate)
 		require.ErrorContains(t, err, "destination chain ")
 	})
 
@@ -126,14 +127,14 @@ func TestCreateMetaData(t *testing.T) {
 		txSnd := NewTxSender(configs)
 
 		_, err := txSnd.CreateMetadata(
-			senderAddr, "prime1", "vector", []BridgingTxReceiver{}, bridgingFeeAmount, exchangeRate)
+			context.Background(), senderAddr, "prime1", "vector", []BridgingTxReceiver{}, bridgingFeeAmount, exchangeRate)
 		require.ErrorContains(t, err, "source chain ")
 	})
 
 	t.Run("invalid amount native token on source", func(t *testing.T) {
 		txSnd := NewTxSender(configs)
 
-		_, err := txSnd.CreateMetadata(senderAddr, "prime", "vector", []BridgingTxReceiver{
+		_, err := txSnd.CreateMetadata(context.Background(), senderAddr, "prime", "vector", []BridgingTxReceiver{
 			{
 				BridgingType: BridgingTypeNativeTokenOnSource,
 				Amount:       19,
@@ -145,7 +146,7 @@ func TestCreateMetaData(t *testing.T) {
 	t.Run("invalid amount currency on source", func(t *testing.T) {
 		txSnd := NewTxSender(configs)
 
-		_, err := txSnd.CreateMetadata(senderAddr, "prime", "vector", []BridgingTxReceiver{
+		_, err := txSnd.CreateMetadata(context.Background(), senderAddr, "prime", "vector", []BridgingTxReceiver{
 			{
 				BridgingType: BridgingTypeCurrencyOnSource,
 				Amount:       9,
@@ -157,7 +158,7 @@ func TestCreateMetaData(t *testing.T) {
 	t.Run("invalid bridging fee", func(t *testing.T) {
 		txSnd := NewTxSender(configs)
 
-		_, err := txSnd.CreateMetadata(senderAddr, "prime", "vector", []BridgingTxReceiver{
+		_, err := txSnd.CreateMetadata(context.Background(), senderAddr, "prime", "vector", []BridgingTxReceiver{
 			{
 				BridgingType: BridgingTypeCurrencyOnSource,
 				Amount:       9,
@@ -178,7 +179,7 @@ func TestCreateMetaData(t *testing.T) {
 			},
 		})
 
-		_, err := txSnd.CreateMetadata(senderAddr, "prime", "vector", []BridgingTxReceiver{
+		_, err := txSnd.CreateMetadata(context.Background(), senderAddr, "prime", "vector", []BridgingTxReceiver{
 			{
 				BridgingType: BridgingTypeNormal,
 				Amount:       189,

--- a/wallet/transaction_extended.go
+++ b/wallet/transaction_extended.go
@@ -44,17 +44,12 @@ func GetTokenCostSum(txBuilder *TxBuilder, userAddress string, utxos []Utxo) (ui
 
 	for tokenName, amount := range userTokenSum {
 		if tokenName != AdaTokenName {
-			token, err := NewTokenWithFullName(tokenName, false)
+			token, err := NewTokenWithFullName(tokenName, true)
 			if err != nil {
-				token, err = NewTokenWithFullName(tokenName, true)
-				if err != nil {
-					return 0, err
-				}
+				return 0, err
 			}
 
-			tokenAmount := NewTokenAmount(token, amount)
-
-			txOutput.Tokens = append(txOutput.Tokens, tokenAmount)
+			txOutput.Tokens = append(txOutput.Tokens, NewTokenAmount(token, amount))
 		}
 	}
 	retSum, err := txBuilder.CalculateMinUtxo(txOutput)

--- a/wallet/transaction_extended_test.go
+++ b/wallet/transaction_extended_test.go
@@ -44,25 +44,29 @@ func TestGetTokenCostSum(t *testing.T) {
 			},
 		},
 	}
+
 	result, err := GetTokenCostSum(txBuilder, address, utxos)
 	require.NoError(t, err)
-	require.Equal(t, uint64(1293000), result)
+	require.Equal(t, uint64(1189560), result)
 
 	utxos[1].Tokens[0].Amount = 1 // changing token amount will change the output
+
 	result, err = GetTokenCostSum(txBuilder, address, utxos)
 	require.NoError(t, err)
-	require.Equal(t, uint64(1275760), result)
+	require.Equal(t, uint64(1172320), result)
 
 	utxos[2].Tokens[0].Amount = 3 // changing token amount will change the output
+
 	result, err = GetTokenCostSum(txBuilder, address, utxos)
 	require.NoError(t, err)
-	require.Equal(t, uint64(1241280), result)
+	require.Equal(t, uint64(1137840), result)
 
 	utxos[0].Amount = 3
 	utxos[1].Amount = 300_021_416_931_256_900 // changing lovelace amounts won't make any difference
+
 	result, err = GetTokenCostSum(txBuilder, address, utxos)
 	require.NoError(t, err)
-	require.Equal(t, uint64(1241280), result)
+	require.Equal(t, uint64(1137840), result)
 }
 
 func TestCreateTxOutputChange(t *testing.T) {


### PR DESCRIPTION
When creating metadata, when setting .Additional for BridgingTypeCurrencyOnSource, dstConfig.MinUtxoValue should not be used as is.  Use the function to calculate the token cost and use max(minUtxo, txBuilder.CalculateMinUtxo)
When there is BridgingTypeNativeTokenOnSource, calculate minUtxo value for src tx and if lovelace amount for src tx is less then calculated minUtxo, update it to new value. 
Change populateTxBuilder function to check if change sum contains native tokens and calculate minUtxo for change output.