### PR TITLE
bugfix: AD-660 Skyline txSender incorrectly uses infra.GetUTXOsForAmounts, causing wrong change calculation in specific cases

### DIFF
--- a/sendtx/tx_sender.go
+++ b/sendtx/tx_sender.go
@@ -445,6 +445,12 @@ func (txSnd *TxSender) populateTxBuilder(
 		utxos = txSnd.utxosTransformer.TransformUtxos(utxos)
 	}
 
+	// The condition for lovelace is:
+	// `currLovelace == condLovelace || currLovelace >= condLovelace + minUtxoLovelace`
+	// However, since the fee payer is the same address that is funding the outputs,
+	// we must skip the `currLovelace == condLovelace` case.
+	// This can be achieved by setting `minUtxoLovelace` to 0,
+	// and instead adding `minUtxoLovelace` directly to the lovelace condition.
 	inputs, err := GetUTXOsForAmounts(utxos, conditions, 0, txSnd.maxInputsPerTx, 1)
 	if err != nil {
 		return nil, err

--- a/sendtx/tx_sender.go
+++ b/sendtx/tx_sender.go
@@ -445,13 +445,7 @@ func (txSnd *TxSender) populateTxBuilder(
 		utxos = txSnd.utxosTransformer.TransformUtxos(utxos)
 	}
 
-	// The condition for lovelace is:
-	// `currLovelace == condLovelace || currLovelace >= condLovelace + minUtxoLovelace`
-	// However, since the fee payer is the same address that is funding the outputs,
-	// we must skip the `currLovelace == condLovelace` case.
-	// This can be achieved by setting `minUtxoLovelace` to 0,
-	// and instead adding `minUtxoLovelace` directly to the lovelace condition.
-	inputs, err := GetUTXOsForAmounts(utxos, conditions, 0, txSnd.maxInputsPerTx, 1)
+	inputs, err := GetUTXOsForAmounts(utxos, conditions, txSnd.maxInputsPerTx, 1)
 	if err != nil {
 		return nil, err
 	}

--- a/sendtx/tx_sender.go
+++ b/sendtx/tx_sender.go
@@ -434,7 +434,7 @@ func (txSnd *TxSender) populateTxBuilder(
 	potentialFee := setOrDefault(config.PotentialFee, defaultPotentialFee)
 
 	conditions := map[string]uint64{
-		cardanowallet.AdaTokenName: outputLovelace + potentialFee,
+		cardanowallet.AdaTokenName: outputLovelace + potentialFee + srcChangeMinUtxo,
 	}
 
 	for _, token := range outputNativeTokens {
@@ -445,7 +445,7 @@ func (txSnd *TxSender) populateTxBuilder(
 		utxos = txSnd.utxosTransformer.TransformUtxos(utxos)
 	}
 
-	inputs, err := GetUTXOsForAmounts(utxos, conditions, srcChangeMinUtxo, txSnd.maxInputsPerTx, 1)
+	inputs, err := GetUTXOsForAmounts(utxos, conditions, 0, txSnd.maxInputsPerTx, 1)
 	if err != nil {
 		return nil, err
 	}

--- a/sendtx/utxo_helper.go
+++ b/sendtx/utxo_helper.go
@@ -12,16 +12,17 @@ import (
 // to a maximum input limit per transaction.
 //
 // Parameters:
-// - utxos: A list of available UTXOs for selection.
-// - conditions: A map defining required token conditions (e.g., exact or minimum amounts).
-// - minUtxoLovelace: for lovelace, the condition must be met exactly, or there must be at least
-// minUtxoLovelace worth of additional tokens to create change
-// - maxInputsPerTx: The maximum number of UTXOs that should be returned.
-// - tryAtLeastInputsPerTx: If possible it should be returned at least this number of UTXOs
+//   - utxos: A list of available UTXOs for selection.
+//   - conditions: A map defining required token conditions (e.g., exact or minimum amounts).
+//   - minUtxoLovelace: For lovelace, the condition must be met exactly,
+//     or there must be at least `minUtxoLovelace` more to allow for change creation.
+//     Can be set to zero if we want to skip the exact match condition.
+//   - maxInputs: The maximum number of UTXOs that should be returned.
+//   - tryAtLeastInputs: If possible it should be returned at least this number of UTXOs
 //
 // Returns:
-// - cardanowallet.TxInputs: Selected UTXOs and their total sum if conditions are met.
-// - error: An error if no valid selection can satisfy the conditions.
+// - Selected UTXOs and their total sum if conditions are met (cardanowallet.TxInputs)
+// - An error if no valid selection can satisfy the conditions.
 //
 // The function iteratively selects UTXOs, replacing the smallest ones when the limit is reached,
 // until the specified conditions are satisfied or no valid selection is possible.

--- a/sendtx/utxo_helper_test.go
+++ b/sendtx/utxo_helper_test.go
@@ -71,7 +71,7 @@ func TestGetUTXOsForAmounts(t *testing.T) {
 		require.Equal(t, len(utxos), len(mp))
 	}
 
-	t.Run("exact amount with zero minUtxoLovelace", func(t *testing.T) {
+	t.Run("exact amount", func(t *testing.T) {
 		utxosNew := []cardanowallet.Utxo{
 			{
 				Hash:   "1",
@@ -95,7 +95,7 @@ func TestGetUTXOsForAmounts(t *testing.T) {
 		}
 		txInputs, err := GetUTXOsForAmounts(utxosNew, map[string]uint64{
 			cardanowallet.AdaTokenName: 130,
-		}, 0, 2, 1)
+		}, 2, 1)
 
 		require.NoError(t, err)
 		assert.Equal(t, map[string]uint64{
@@ -114,43 +114,13 @@ func TestGetUTXOsForAmounts(t *testing.T) {
 		checkAllAreThere(t, utxosNew)
 	})
 
-	t.Run("exact amount", func(t *testing.T) {
-		utxosNew := slices.Clone(utxos)
-
-		txInputs, err := GetUTXOsForAmounts(utxosNew, map[string]uint64{
-			cardanowallet.AdaTokenName: 610,
-		}, 50, 4, 1)
-
-		require.NoError(t, err)
-		assert.Equal(t, map[string]uint64{
-			cardanowallet.AdaTokenName: 610,
-			"1.31":                     50,
-		}, txInputs.Sum)
-		assert.Equal(t, []cardanowallet.TxInput{
-			{
-				Hash: "1",
-			},
-			{
-				Hash: "4",
-			},
-			{
-				Hash: "3",
-			},
-			{
-				Hash: "5",
-			},
-		}, txInputs.Inputs)
-
-		checkAllAreThere(t, utxosNew)
-	})
-
 	t.Run("greater amount", func(t *testing.T) {
 		utxosNew := slices.Clone(utxos)
 
 		txInputs, err := GetUTXOsForAmounts(utxosNew, map[string]uint64{
-			cardanowallet.AdaTokenName: 1240,
+			cardanowallet.AdaTokenName: 1255,
 			"1.31":                     150,
-		}, 15, 7, 1)
+		}, 7, 1)
 
 		require.NoError(t, err)
 		assert.Equal(t, map[string]uint64{
@@ -188,9 +158,9 @@ func TestGetUTXOsForAmounts(t *testing.T) {
 		utxosNew := slices.Clone(utxos)
 
 		txInputs, err := GetUTXOsForAmounts(utxosNew, map[string]uint64{
-			cardanowallet.AdaTokenName: 200,
+			cardanowallet.AdaTokenName: 250,
 			"1.31":                     410,
-		}, 50, 2, 1)
+		}, 2, 1)
 
 		require.NoError(t, err)
 		assert.Equal(t, map[string]uint64{
@@ -215,7 +185,7 @@ func TestGetUTXOsForAmounts(t *testing.T) {
 		txInputs, err := GetUTXOsForAmounts(utxosNew, map[string]uint64{
 			cardanowallet.AdaTokenName: 200,
 			"1.31":                     700,
-		}, 10, 3, 1)
+		}, 3, 1)
 
 		require.NoError(t, err)
 		assert.Equal(t, map[string]uint64{
@@ -241,9 +211,9 @@ func TestGetUTXOsForAmounts(t *testing.T) {
 		utxosNew := slices.Clone(utxos)
 
 		_, err := GetUTXOsForAmounts(utxosNew, map[string]uint64{
-			cardanowallet.AdaTokenName: 200,
+			cardanowallet.AdaTokenName: 250,
 			"1.31":                     500,
-		}, 50, 1, 1)
+		}, 1, 1)
 
 		require.ErrorIs(t, err, cardanowallet.ErrUTXOsLimitReached)
 
@@ -254,9 +224,9 @@ func TestGetUTXOsForAmounts(t *testing.T) {
 		utxosNew := slices.Clone(utxos)
 
 		_, err := GetUTXOsForAmounts(utxosNew, map[string]uint64{
-			cardanowallet.AdaTokenName: 300,
+			cardanowallet.AdaTokenName: 350,
 			"1.31":                     1000,
-		}, 50, 3, 1)
+		}, 3, 1)
 
 		require.ErrorIs(t, err, cardanowallet.ErrUTXOsCouldNotSelect)
 
@@ -287,8 +257,8 @@ func TestGetUTXOsForAmounts(t *testing.T) {
 		}
 
 		txInputs, err := GetUTXOsForAmounts(utxos, map[string]uint64{
-			cardanowallet.AdaTokenName: 1000,
-		}, 50, 5, 4)
+			cardanowallet.AdaTokenName: 1050,
+		}, 5, 4)
 
 		require.NoError(t, err)
 		assert.Equal(t, map[string]uint64{
@@ -315,28 +285,20 @@ func TestGetUTXOsForAmounts(t *testing.T) {
 }
 
 func TestDoesSumSatisfyCondition(t *testing.T) {
-	t.Run("equal currency", func(t *testing.T) {
-		require.True(t, doesSumSatisfyCondition(map[string]uint64{
-			cardanowallet.AdaTokenName: 100,
-		}, map[string]uint64{
-			cardanowallet.AdaTokenName: 100,
-		}, 50))
-	})
-
-	t.Run("currency with change", func(t *testing.T) {
+	t.Run("currency exact", func(t *testing.T) {
 		require.True(t, doesSumSatisfyCondition(map[string]uint64{
 			cardanowallet.AdaTokenName: 150,
 		}, map[string]uint64{
-			cardanowallet.AdaTokenName: 100,
-		}, 50))
+			cardanowallet.AdaTokenName: 150,
+		}))
 	})
 
 	t.Run("currency not enough change", func(t *testing.T) {
 		require.False(t, doesSumSatisfyCondition(map[string]uint64{
 			cardanowallet.AdaTokenName: 149,
 		}, map[string]uint64{
-			cardanowallet.AdaTokenName: 100,
-		}, 50))
+			cardanowallet.AdaTokenName: 150,
+		}))
 	})
 
 	t.Run("not enough tokens", func(t *testing.T) {
@@ -346,7 +308,7 @@ func TestDoesSumSatisfyCondition(t *testing.T) {
 		}, map[string]uint64{
 			cardanowallet.AdaTokenName: 100,
 			"1.31":                     250,
-		}, 50))
+		}))
 	})
 
 	t.Run("enough tokens and currency", func(t *testing.T) {
@@ -354,8 +316,8 @@ func TestDoesSumSatisfyCondition(t *testing.T) {
 			cardanowallet.AdaTokenName: 155,
 			"1.31":                     250,
 		}, map[string]uint64{
-			cardanowallet.AdaTokenName: 100,
+			cardanowallet.AdaTokenName: 150,
 			"1.31":                     250,
-		}, 50))
+		}))
 	})
 }


### PR DESCRIPTION
- System requests UTXOs totaling 81,386,732 lovelace (80,886,732 for outputs + 500,000 estimated fee)
- GetUTXOsForAmounts returns UTXOs with exactly this sum due to audit requirements
- Actual fee calculation shows only 175,841 needed
- Results in insufficient change (81,386,732 - 80,886,732 - 175,841 = 324,159) which is below minUTxO


```
--- FAIL: Test_E2E_SkylineTestnetDefund (1139.17s)
    testnet_skyline_test.go:181:
        	Error Trace:	/home/igor/development/ethernal/apex-bridge/blade-apex-bridge/e2e-polybft/e2e/testnet_skyline_test.go:181
        	Error:      	Received unexpected error:
        	            	error while defunding addr addr_test1vpq52qandd5wkw3sur2lz7clljet09u7xar9nkka26l80ps8vn58a: insufficient remaining amount 500000 for fee 175841, or minimum UTXO (1000000) not satisfied
        	Test:       	Test_E2E_SkylineTestnetDefund
FAIL
```
 


